### PR TITLE
fix faker params

### DIFF
--- a/test/controllers/wobject/test.js
+++ b/test/controllers/wobject/test.js
@@ -107,12 +107,12 @@ describe('On wobjController', async () => {
       await dropDatabase();
       skip = _.random(1, 3);
       limit = _.random(6, 9);
-      authorPermlink = faker.random.string(10);
-      newsFilterPermlink = faker.random.string(100);
-      allowObjectPermlinks = faker.random.string(1000);
+      authorPermlink = faker.random.string(20);
+      newsFilterPermlink = faker.random.string(20);
+      allowObjectPermlinks = faker.random.string(20);
 
       await AppendObjectFactory.Create({
-        name: faker.random.string(1000),
+        name: faker.random.string(20),
         rootWobj: authorPermlink,
         permlink: newsFilterPermlink,
         body: JSON.stringify({ allowList: [[allowObjectPermlinks]] }),

--- a/test/controllers/wobject/test.js
+++ b/test/controllers/wobject/test.js
@@ -107,24 +107,27 @@ describe('On wobjController', async () => {
       await dropDatabase();
       skip = _.random(1, 3);
       limit = _.random(6, 9);
-      authorPermlink = faker.random.string(100);
+      authorPermlink = faker.random.string(10);
       newsFilterPermlink = faker.random.string(100);
-      allowObjectPermlinks = faker.random.string(100);
+      allowObjectPermlinks = faker.random.string(1000);
 
       await AppendObjectFactory.Create({
+        name: faker.random.string(1000),
         rootWobj: authorPermlink,
         permlink: newsFilterPermlink,
         body: JSON.stringify({ allowList: [[allowObjectPermlinks]] }),
       });
 
-      for (let i = 0; i < _.random(10, 15); i++) {
+      for (let i = 0; i < _.random(15, 25); i++) {
         await UserWobjectsFactory.Create({
+          userName: faker.random.string(1000),
           authorPermlink,
           weight: _.random(1, 10000),
         });
       }
-      for (let i = 0; i < _.random(10, 15); i++) {
+      for (let i = 0; i < _.random(15, 25); i++) {
         await UserWobjectsFactory.Create({
+          userName: faker.random.string(1000),
           authorPermlink: allowObjectPermlinks,
           weight: _.random(1, 10000),
         });

--- a/test/models/WebsitePaymentsModel/test.js
+++ b/test/models/WebsitePaymentsModel/test.js
@@ -108,8 +108,8 @@ describe('WebsitePaymentsModel', () => {
   });
 
   describe('On distinct', () => {
-    const name1 = faker.random.string(1000);
-    const name2 = faker.random.string(100);
+    const name1 = faker.random.string(20);
+    const name2 = faker.random.string(20);
     const amount = _.random(10, 25);
     let name;
     beforeEach(async () => {

--- a/test/models/WebsitePaymentsModel/test.js
+++ b/test/models/WebsitePaymentsModel/test.js
@@ -108,15 +108,18 @@ describe('WebsitePaymentsModel', () => {
   });
 
   describe('On distinct', () => {
-    const name1 = faker.name.firstName();
-    const name2 = faker.name.firstName();
+    const name1 = faker.random.string(1000);
+    const name2 = faker.random.string(100);
     const amount = _.random(10, 25);
-    const counter = _.random(3, 10);
+    let name;
     beforeEach(async () => {
       await dropDatabase();
-      for (let i = 0; i < counter; i++) {
+      for (let i = 0; i < _.random(25, 40); i++) {
+        if (i % 2 === 0) {
+          name = name1;
+        } else name = name2;
         await WebsitePaymentsFactory.Create({
-          name: _.sample([name1, name2]),
+          name,
           amount,
         });
       }


### PR DESCRIPTION
Changed the default data creation when creating an entity from "faker.name.firstName()" to "faker.random.string(1000)" because the data could sometimes match