### PR TITLE
(Git-2854) Fixed display of names on "Filter posts"

### DIFF
--- a/utilities/helpers/wObjectHelper.js
+++ b/utilities/helpers/wObjectHelper.js
@@ -455,10 +455,24 @@ const processWobjects = async ({
   return filteredWobj;
 };
 
+const getCurrentNames = async (names) => {
+  const { result: wobjects } = await Wobj.find(
+    { author_permlink: { $in: names } }, { author_permlink: 1, fields: 1 },
+  );
+  const result = await Promise.all(wobjects.map(async (wobject) => {
+    const { name } = await processWobjects({
+      wobjects: [wobject], fields: [FIELDS_NAMES.NAME], returnArray: false,
+    });
+    return { author_permlink: wobject.author_permlink, name };
+  }));
+  return { result };
+};
+
 module.exports = {
   getUserSharesInWobj,
   getLinkToPageLoad,
   getWobjectFields,
+  getCurrentNames,
   processWobjects,
   getParentInfo,
 };


### PR DESCRIPTION
Changed the display of names on filters from author_premlinks to the actual name of the object